### PR TITLE
Bump cryptography from 42.0.5 to 43.0.1 in jbs/cnrts/bookie

### DIFF
--- a/jbs/cnrts/bookie/pyproject.toml
+++ b/jbs/cnrts/bookie/pyproject.toml
@@ -5,7 +5,7 @@ dependencies = [
     'importlib-metadata; python_version<"3.10"',
     "requests",
     "PyJWT==2.8.0",
-    "cryptography==42.0.5",
+    "cryptography==43.0.1",
 ]
 [projects.scripts]
 cli = "bookie:main"


### PR DESCRIPTION
Fixes dependabot alert #4.

- Updated `cryptography==42.0.5` → `cryptography==43.0.1` in `jbs/cnrts/bookie/pyproject.toml`
- Note: file was previously moved from `ints/` to `jbs/` in a prior commit
- All 3 tests passed (`test_Ask`, `test_Bid`, `test_OrderBook`)